### PR TITLE
Fix issue when flashing slots A and B

### DIFF
--- a/n0110/dfu-util.js
+++ b/n0110/dfu-util.js
@@ -692,13 +692,13 @@ var device = null;
         uploadSlotAButton.addEventListener('click', uploadEventListener(async function(maxSize) {
           device.startAddress = 0x90000000;
           const blob = await device.do_upload(transferSize, 4096*1024);
-          saveAs(blob, "external.bin");
+          saveAs(blob, "slotA.bin");
         }));
 
         uploadSlotBButton.addEventListener('click', uploadEventListener(async function(maxSize) {
           device.startAddress = 0x90400000;
           const blob = await device.do_upload(transferSize, 4096*1024);
-          saveAs(blob, "external.bin");
+          saveAs(blob, "slotB.bin");
         }));
 
         firmwareFileField.addEventListener("change", function() {
@@ -776,7 +776,7 @@ var device = null;
           return device.do_download(transferSize, firmwareFile, false);
         }));
 
-        downloadSlotAButton.addEventListener('click', downloadEventListener(async function() {
+        downloadSlotBButton.addEventListener('click', downloadEventListener(async function() {
           device.startAddress = 0x90040000;
           return device.do_download(transferSize, firmwareFile, false);
         }));


### PR DESCRIPTION
I realized I made a typo in my previous PR: Clicking "Flash Slot A" flashes slot A and B, clicking "Flash Slot B" does nothing. This is a fix for that issue. I also took the opportunity to give a name to the files you get when dumping Slot A and Slot B.